### PR TITLE
Accept value '0' for select, radio field

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -201,9 +201,13 @@ class CMB2_Types {
 		$method = isset( $args['method'] ) ? $args['method'] : 'select_option';
 		unset( $args['method'] );
 
-		$value = $this->field->escaped_value()
-			? $this->field->escaped_value()
-			: $this->field->args( 'default' );
+	        if( cmb2_utils()->isempty( $this->field->escaped_value() ) ) {
+	            $value = $this->field->args( 'default' );
+	            $value_isempty = true;
+	        } else {
+	            $value = $this->field->escaped_value();
+	            $value_isempty = false;
+	        }
 
 		$concatenated_items = ''; $i = 1;
 		foreach ( (array) $this->field->options() as $opt_value => $opt_label ) {
@@ -215,7 +219,7 @@ class CMB2_Types {
 			$a['label'] = $opt_label;
 
 			// Check if this option is the value of the input
-			if ( $value == $opt_value ) {
+			if ( $value === $opt_value || ( !$value_isempty && $value == $opt_value ) ) {
 				$a['checked'] = 'checked';
 			}
 

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -219,7 +219,7 @@ class CMB2_Types {
 			$a['label'] = $opt_label;
 
 			// Check if this option is the value of the input
-			if ( $value === $opt_value || ( !$value_isempty && $value == $opt_value ) ) {
+			if ( ( $value_isempty && cmb2_utils()->isempty( $opt_value ) ) || ( !$value_isempty && $value == $opt_value ) ) {
 				$a['checked'] = 'checked';
 			}
 

--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -126,7 +126,7 @@ class CMB2_Utils {
 	 * @return bool         True or false
 	 */
 	public function isempty( $value ) {
-		return is_null( $value ) || ( is_string( $value ) && empty( $value ) );
+		return empty( $value ) && $value != '0';
 	}
 
 	/**


### PR DESCRIPTION
Problem: https://github.com/WebDevStudios/CMB2/issues/115

Current isempty function returns true with value '0'.

With this code we can accept both '0' and 0.
empty( $value ) && $value != '0'

Then we can properly check if value is empty.

Works with select and radio field.
Multicheck field still doesn't work if we set value to 0.