### PR TITLE
Fixes related to repeatable/sortable groups of fields

### DIFF
--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -631,9 +631,18 @@ window.CMB2 = (function(window, document, $, undefined){
 
 			}
 			// handle checkbox swapping
-			else if ( 'checkbox' === $element.attr('type') || 'radio' === $element.attr( 'type' )  ) {
+			else if ( 'checkbox' === $element.attr('type') ) {
 				inputVals[ index ]['$'].prop( 'checked', $element.is(':checked') );
 				$element.prop( 'checked', inputVals[ index ]['val'] );
+			}
+			// handle radio swapping
+			else if ( 'radio' === $element.attr( 'type' )  ) {
+				if ($element.is(':checked')) {
+					inputVals[index]['$'].attr('data-checked', 'true');
+				}
+				if (inputVals[index]['$'].is(':checked')) {
+					$element.attr('data-checked', 'true');	
+				}
 			}
 			// handle select swapping
 			else if ( 'select' === $element.prop('tagName') ) {
@@ -646,6 +655,9 @@ window.CMB2 = (function(window, document, $, undefined){
 				$element.val( inputVals[ index ]['val'] );
 			}
 		});
+
+		$parent.find("input[data-checked=true]").prop('checked', true).removeAttr('data-checked');
+		$goto.find("input[data-checked=true]").prop('checked', true).removeAttr('data-checked');
 
 		// shift done
 		$self.trigger( 'cmb2_shift_rows_complete', $self );

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -348,7 +348,11 @@ window.CMB2 = (function(window, document, $, undefined){
 
 			$newInput
 				.removeClass( 'hasDatepicker' )
-				.attr( attrs ).val('');
+				.attr( attrs );//.val('');
+				
+			if ($newInput.attr('type')!='radio' && $newInput.attr('type')!='checkbox') {
+				$newInput.val('');
+			}				
 
 			// wysiwyg field
 			if ( isEditor ) {
@@ -466,7 +470,7 @@ window.CMB2 = (function(window, document, $, undefined){
 	};
 
 	cmb.emptyValue = function( evt, row ) {
-		$('input:not([type="button"]), textarea', row).val('');
+		$('input:not([type="button"],[type="radio"],[type="checkbox"]), textarea', row).val('');
 	};
 
 	cmb.addGroupRow = function( evt ) {

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -23,7 +23,7 @@ window.CMB2 = (function(window, document, $, undefined){
 		formfield          : '',
 		idNumber           : false,
 		file_frames        : {},
-		repeatEls          : 'input:not([type="button"]),select,textarea,.cmb2-media-status',
+		repeatEls          : 'input:not([type="button"],[id^=filelist]),select,textarea,.cmb2-media-status',
 		defaults : {
 			time_picker  : l10n.defaults.time_picker,
 			date_picker  : l10n.defaults.date_picker,
@@ -625,9 +625,24 @@ window.CMB2 = (function(window, document, $, undefined){
 
 			if ( $element.hasClass('cmb2-media-status') ) {
 				// special case for image previews
+
+				var toRowId = $element.closest('.cmb-repeatable-grouping').attr('data-iterator');
+				var fromRowId = inputVals[ index ]['$'].closest('.cmb-repeatable-grouping').attr('data-iterator');
+				
 				val = $element.html();
 				$element.html( inputVals[ index ]['val'] );
 				inputVals[ index ]['$'].html( val );
+
+				inputVals[ index ]['$'].find('input').each(function() {
+					var name = $(this).attr('name');
+					name = name.replace('['+toRowId+']', '['+fromRowId+']');
+					$(this).attr('name', name);
+				});
+				$element.find('input').each(function() {
+					var name = $(this).attr('name');
+					name = name.replace('['+fromRowId+']', '['+toRowId+']');
+					$(this).attr('name', name);
+				});
 
 			}
 			// handle checkbox swapping


### PR DESCRIPTION
I had some issues with a repeatable and sortable group that contained a radio_inline field and a file_list field. 

The radio button issues were documented in #150  and #152. 

There were a few bugs when trying to sort a group that had a file_list. 

1. There was a javascript error in the loop of `$goto.find( cmb.repeatEls ).each( function( index )` if the number of images in the two file_lists being swapped differed. This was because the `index` id was based off the number of `input` elements, which are hidden for file_lists. I fixed this on line 26 `repeatEls          : 'input:not([type="button"],[id^=filelist]),select,textarea,.cmb2-media-status',`
2. The attribute names of the file_list hidden input fields that set the image id didn't correspond with the correct row number. This is fixed in line `629 to 645`