### PR TITLE
Run stripslashes before saving data, since WordPress forces magic quotes

### DIFF
--- a/CMB2.php
+++ b/CMB2.php
@@ -391,7 +391,7 @@ class CMB2 {
 	 */
 	public function save_fields( $object_id = 0, $object_type = '', $data_to_save ) {
 
-		$this->data_to_save = $data_to_save;
+		$this->data_to_save = stripslashes_deep($data_to_save);
 		$object_id = $this->object_id( $object_id );
 		$object_type = $this->object_type( $object_type );
 

--- a/CMB2.php
+++ b/CMB2.php
@@ -391,7 +391,7 @@ class CMB2 {
 	 */
 	public function save_fields( $object_id = 0, $object_type = '', $data_to_save ) {
 
-		$this->data_to_save = stripslashes_deep($data_to_save);
+		$this->data_to_save = $data_to_save;
 		$object_id = $this->object_id( $object_id );
 		$object_type = $this->object_type( $object_type );
 

--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -27,7 +27,7 @@ class CMB2_Sanitize {
 	 */
 	public function __construct( CMB2_Field $field, $value ) {
 		$this->field = $field;
-		$this->value = $value;
+		$this->value = stripslashes_deep($value); // get rid of those evil magic quotes
 	}
 
 	/**


### PR DESCRIPTION
We found that when entering a single tick `'` into text fields, the resulting save adds an unnecessary escape character: `\'`

This is because of that weird legacy quirk with WordPress that forces magic quotes onto all incoming data, whether `$_GET` or `$_POST`. This happens regardless of the PHP setting so trying to use `get_magic_quotes_gpc()` in this context does not work. (See note here: http://codex.wordpress.org/Function_Reference/stripslashes_deep) 

This patch uses stripslashes_deep to nuke all of these befor storing fields in the database. We've tested and it works perfectly. 