### PR TITLE
use attachment_url_to_postid instead of custom url to id function

### DIFF
--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -20,6 +20,11 @@ class CMB2_Utils {
 	 * @return mixed            Attachment ID or false
 	 */
 	public function image_id_from_url( $img_url ) {
+		// Since WP 4.0.0
+		if( function_exists( 'attachment_url_to_postid' ) {
+			return attachment_url_to_postid( $img_url );
+		}
+
 		global $wpdb;
 
 		$img_url = esc_url_raw( $img_url );


### PR DESCRIPTION
In WordPress 4.0.0 attachment_url_to_postid was added.

I could remove the `function_exists( 'attachment_url_to_postid' )` check, but that would require the project to bump its minimum WP version.