### PR TITLE
List none

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -205,7 +205,20 @@ class CMB2_Types {
 			? $this->field->escaped_value()
 			: $this->field->args( 'default' );
 
-		$concatenated_items = ''; $i = 1;
+		$concatenated_items = '';
+
+		// Check for option_none
+		if( $this->field->args( 'option_none' ) ) {
+			$a = $args;
+
+			$a['value'] = 0;
+			$a['label'] = $this->field->args( 'option_none' );
+
+			$concatenated_items .= $this->$method( $a );
+		}
+
+		$i = 1;
+
 		foreach ( (array) $this->field->options() as $opt_value => $opt_label ) {
 
 			// Clone args & modify for just this item

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -208,13 +208,13 @@ class CMB2_Types {
 		$concatenated_items = '';
 
 		// Check for option_none
-		if( $this->field->args( 'option_none' ) ) {
+		if( $this->field->args( 'type' ) != 'multicheck' && $this->field->args( 'option_none' ) ) {
 			$a = $args;
 
 			$a['value'] = 0;
 			$a['label'] = $this->field->args( 'option_none' );
 
-			$concatenated_items .= $this->$method( $a );
+			$concatenated_items .= $this->$method( $a, 0 );
 		}
 
 		$i = 1;


### PR DESCRIPTION
New arg: option_none. For select and radio boxes. Useful to have this argument instead of adding an extra "empty" value into the options array.