### PR TITLE
use attachment_url_to_postid instead of custom url to id function

### DIFF
--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -20,6 +20,11 @@ class CMB2_Utils {
 	 * @return mixed            Attachment ID or false
 	 */
 	public function image_id_from_url( $img_url ) {
+		// Since WP 4.0.0
+		if( function_exists( 'attachment_url_to_postid' ) {
+			return attachment_url_to_postid( $img_url );
+		}
+
 		global $wpdb;
 
 		$img_url = esc_url_raw( $img_url );

--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -21,7 +21,7 @@ class CMB2_Utils {
 	 */
 	public function image_id_from_url( $img_url ) {
 		// Since WP 4.0.0
-		if( function_exists( 'attachment_url_to_postid' ) {
+		if( function_exists( 'attachment_url_to_postid' ) ) {
 			return attachment_url_to_postid( $img_url );
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -134,7 +134,7 @@ If including the library in your plugin or theme:
 * Fix metabox form not being returned to caller. Props [akshayagarwal](https://github.com/akshayagarwal), ([#145](https://github.com/WebDevStudios/CMB2/pull/145)).
 * Run stripslashes before saving data, since WordPress forces magic quotes. Props [clifgriffin](https://github.com/clifgriffin), ([#162](https://github.com/WebDevStudios/CMB2/pull/162)).
 
-**[View complete changelog](https://github.com/WebDevStudios/CMB2/blob/master/CONTRIBUTING.md)**
+**[View complete changelog](https://github.com/WebDevStudios/CMB2/blob/master/CHANGELOG.md)**
 
 ## Known Issues
 


### PR DESCRIPTION
Sorry - trying again :)

In WordPress 4.0.0 attachment_url_to_postid was added.

I could remove the `function_exists( 'attachment_url_to_postid' )` check, but that would require the project to bump its minimum WP version.