### PR TITLE
Add autoload to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
+    },
+    "autoload": {
+        "files": ["init.php"]
     }
 }


### PR DESCRIPTION
This remove the need to do this:

```
if ( file_exists(  __DIR__ . '/cmb2/init.php' ) ) {
  require_once  __DIR__ . '/cmb2/init.php';
} elseif ( file_exists(  __DIR__ . '/CMB2/init.php' ) ) {
  require_once  __DIR__ . '/CMB2/init.php';
}
``` 

Using the autoload from composer is the right thing to do.