### PR TITLE
Fix text_datetime_timestamp_timezone in comment

### DIFF
--- a/example-functions.php
+++ b/example-functions.php
@@ -157,12 +157,12 @@ function yourprefix_register_demo_metabox() {
 	// This text_datetime_timestamp_timezone field type
 	// is only compatible with PHP versions 5.3 or above.
 	// Feel free to uncomment and use if your server meets the requirement
-	// array(
+	// $cmb_demo->add_field( array(
 	// 	'name' => __( 'Test Date/Time Picker/Time zone Combo (serialized DateTime object)', 'cmb2' ),
 	// 	'desc' => __( 'field description (optional)', 'cmb2' ),
 	// 	'id'   => $prefix . 'datetime_timestamp_timezone',
 	// 	'type' => 'text_datetime_timestamp_timezone',
-	// ),
+	// ) );
 	$cmb_demo->add_field( array(
 		'name' => __( 'Test Money', 'cmb2' ),
 		'desc' => __( 'field description (optional)', 'cmb2' ),


### PR DESCRIPTION
Uncommenting the text_datetime_timestamp_timezone field type does not work without this fix.