### PR TITLE
Add group_title_callback option to customize the group title

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -770,8 +770,20 @@ class CMB2_Field {
 	 * @return string        Updated value
 	 */
 	public function replace_hash( $value ) {
-		// Replace hash with 1 based count
-		return str_ireplace( '{#}', ( $this->count() + 1 ), $value );
+		if ( ! is_null( $this->escaped_value ) ) {
+		    // Replace hash with 1 based count
+		    return str_ireplace( '{#}', ( $this->count() + 1 ), $value );
+		} else {
+		    $fields = array();
+		    foreach ( array_values( $this->args( 'fields' ) ) as $field_args ) {
+			$field = new CMB2_Field( array(
+			     'field_args'  => $field_args,
+			     'group_field' => $this,
+			 ) );
+			 $fields[$field_args['id']] = $field->value;
+		     }
+		     return call_user_func($this->options('group_title_callback'), $fields);
+		 }
 	}
 
 	/**


### PR DESCRIPTION
As mentioned in the [WP.org thread](https://wordpress.org/support/topic/customize-group_title-with-callback?replies=2), it is nice to customize the title of an options group to something other than a static field with a number.

This change adds an optional callback that formats the name based off the fields.
 
![kiri-mockup2](https://cloud.githubusercontent.com/assets/14830/6394429/c2c0972e-bdd1-11e4-8c48-74aeb83456ef.png)

```
# add the callback parameter
'group_title' => 'New Widget',
'group_title_callback' => array($this, 'format_group_title'),
```

The title formatting function
```public function format_group_title($fields) {
        return $fields['time'] . ' ' . $fields['name'];
}
```

It's not completely ideal, as when you add an item, before clicking save, the JS formats it with the default title.