### PR TITLE
Add option to store values in individual rows instead of serialized array

### DIFF
--- a/example-functions.php
+++ b/example-functions.php
@@ -280,8 +280,9 @@ function yourprefix_register_demo_metabox() {
 	$cmb_demo->add_field( array(
 		'name'    => __( 'Test Multi Checkbox', 'cmb2' ),
 		'desc'    => __( 'field description (optional)', 'cmb2' ),
-		'id'      => $prefix . 'multicheckbox',
+		'id'      => $prefix . 'multicheckbox2',
 		'type'    => 'multicheck',
+		'multiple' => true, // Store values in individual rows
 		'options' => array(
 			'check1' => __( 'Check One', 'cmb2' ),
 			'check2' => __( 'Check Two', 'cmb2' ),

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -419,17 +419,16 @@ class CMB2_Field {
 
 		$new_value = $this->sanitization_cb( $meta_value );
 		$old       = $this->get_data();
-		// $name      = $this->id();
-		// if ( $this->args( 'multiple' ) && ! $this->args( 'repeatable' ) && ! $this->group ) {
-		// 	$this->remove_data();
-		// 	if ( ! empty( $new_value ) ) {
-		// 		foreach ( $new_value as $add_new ) {
-		// 			$this->updated[] = $name;
-		// 			$this->update_data( $add_new, $name, false );
-		// 		}
-		// 	}
-		// } else
-		if ( ! cmb2_utils()->isempty( $new_value ) && $new_value !== $old ) {
+		$name      = $this->id();
+		if ( $this->args( 'multiple' ) && ! $this->args( 'repeatable' ) && ! $this->group ) {
+			$this->remove_data();
+			if ( ! empty( $new_value ) ) {
+				foreach ( $new_value as $add_new ) {
+					$this->updated[] = $name;
+					$this->update_data( $add_new, false );
+				}
+			}
+		} elseif ( ! cmb2_utils()->isempty( $new_value ) && $new_value !== $old ) {
 			return $this->update_data( $new_value );
 		} elseif ( cmb2_utils()->isempty( $new_value ) ) {
 			return $this->remove_data();


### PR DESCRIPTION
In previous versions, multicheck fields were stored using multiple key/value entries. This was recently changed (maybe due to a bug) so now those fields got saved as serialized arrays. Unfortunately, that change made it impossible to use the "meta_key" and "meta_value" arguments with the get_posts function. 
This patch leaves the possbility to the user with an additional "multiple" option, to store the values as individual rows again.
(Unnecessary changes are due to windows linebreaks in original code)
Fixes #183 