### PR TITLE
Update VERSION constant

### DIFF
--- a/init.php
+++ b/init.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'cmb2_bootstrap_205_trunk', false ) ) {
 		 * @var   string
 		 * @since 1.0.0
 		 */
-		const VERSION = '2.0.4';
+		const VERSION = '2.0.5';
 
 		/**
 		 * Current version hook priority


### PR DESCRIPTION
Version 2.0.5 is 2.0.5 right? Since the class is *_205_trunk, should the VERSION constant be '2.0.5-trunk' also? or should this actually be 2.0.6-trunk since 2.0.5 is already tagged?