### PR TITLE
fix render hidden fields inside group

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -306,13 +306,15 @@ class CMB2 {
 				// Loop and render repeatable group fields
 				foreach ( array_values( $field_group->args( 'fields' ) ) as $field_args ) {
 					if ( 'hidden' == $field_args['type'] ) {
-						$hidden_args = array(
-								'field_args'  => $field_args,
-								'group_field' => $field_group,
-							);
-						$hidden_field = new CMB2_Types( new CMB2_Field( $hidden_args ) );
-						$hidden_field->render();
+
+						// Save rendering for after the metabox
+						$this->add_hidden_field( array(
+							'field_args'  => $field_args,
+							'group_field' => $field_group,
+						) );
+
 					} else {
+
 						$field_args['show_names'] = $field_group->args( 'show_names' );
 						$field_args['context']    = $field_group->args( 'context' );
 

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -307,11 +307,11 @@ class CMB2 {
 				foreach ( array_values( $field_group->args( 'fields' ) ) as $field_args ) {
 					if ( 'hidden' == $field_args['type'] ) {
 
-						// Save rendering for after the metabox
-						$this->add_hidden_field( array(
-							'field_args'  => $field_args,
-							'group_field' => $field_group,
-						) );
+						$hidden_args = array(
+                'field_args'  => $field_args,
+                'group_field' => $field_group,
+              );
+            $hidden_fields[] = new CMB2_Types( new CMB2_Field( $hidden_args ) );
 
 					} else {
 
@@ -321,6 +321,13 @@ class CMB2 {
 						$field = $this->get_field( $field_args, $field_group )->render_field();
 					}
 				}
+				echo '
+				<div class="cmb-hidden-fields-box">';
+				  foreach ($hidden_fields as $hidden_field) {
+				    $hidden_field->render();
+				  }
+				echo '
+				</div>';
 				echo '
 				<div class="cmb-row cmb-remove-field-row">
 					<div class="cmb-remove-row">

--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -306,15 +306,13 @@ class CMB2 {
 				// Loop and render repeatable group fields
 				foreach ( array_values( $field_group->args( 'fields' ) ) as $field_args ) {
 					if ( 'hidden' == $field_args['type'] ) {
-
-						// Save rendering for after the metabox
-						$this->add_hidden_field( array(
-							'field_args'  => $field_args,
-							'group_field' => $field_group,
-						) );
-
+						$hidden_args = array(
+								'field_args'  => $field_args,
+								'group_field' => $field_group,
+							);
+						$hidden_field = new CMB2_Types( new CMB2_Field( $hidden_args ) );
+						$hidden_field->render();
 					} else {
-
 						$field_args['show_names'] = $field_group->args( 'show_names' );
 						$field_args['context']    = $field_group->args( 'context' );
 


### PR DESCRIPTION
It fix #289 

hidden fields of group wrong value when they are reorder.

because It collects hidden fields and then render last of metabox
but I would like to render inside the group for correct value.

It will render hidden fields inside the group