### PR TITLE
Fix 'select' options defined as arrays.

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -217,6 +217,9 @@ class CMB2_Types {
 
 			// Clone args & modify for just this item
 			$a = $args;
+			
+			$opt_value = ( is_array($opt_label) ) ? $opt_label['value'] : $opt_value;
+			$opt_label = ( is_array($opt_label) ) ? $opt_label['name'] : $opt_label;
 
 			$a['value'] = $opt_value;
 			$a['label'] = $opt_label;


### PR DESCRIPTION
If a select option was defined in the old CMB style of:

    'options' => array(
       array('name' => 'Normal Width, Normal Height (285x190px)', 'value' => 'normal'),
    )

The result was broken. The above adds in back compatibility for this formatting style (old CMB).