### PR TITLE
Fix output the multicheck_inline field type

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -713,7 +713,7 @@ class CMB2_Types {
 	}
 
 	public function multicheck_inline() {
-		$this->multicheck( 'multicheck_inline' );
+		return $this->multicheck( 'multicheck_inline' );
 	}
 
 	public function checkbox() {


### PR DESCRIPTION
The function multicheck_inline in CMB2_Types.php must return the html element. Otherwise _render function doesn't echo anything.