### PR TITLE
Fallback for fatal error with invalid timezone

### DIFF
--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -263,7 +263,10 @@ class CMB2_Sanitize {
 		$offset = cmb2_utils()->timezone_offset( $tzstring );
 
 		if ( 'UTC' === substr( $tzstring, 0, 3 ) ) {
-			$tzstring = timezone_name_from_abbr( '', $offset, 0 );
+			// timezone_name_from_abbr() returns false if not found based on offset. 
+			// Since there are currently some invalid timezones in wp_timezone_dropdown(),
+			// fallback to an offset of 0 (UTC+0)
+			$tzstring = ( false !== timezone_name_from_abbr( '', $offset, 0 ) ) ? timezone_name_from_abbr( '', $offset, 0 ) : timezone_name_from_abbr( '', 0, 0 );
 		}
 
 		$this->value = new DateTime( $this->value['date'] . ' ' . $this->value['time'], new DateTimeZone( $tzstring ) );


### PR DESCRIPTION
If an invalid timezone offset is used, fallback to UTC+0

This will catch both invalid timezones submitted from the field as well as an invalid timezone setting in WP that gets used when no timezone is selected from the dropdown.