### PR TITLE
Update CMB2_Utils.php

### DIFF
--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -23,13 +23,13 @@ class CMB2_Utils {
 	 * Utility method that attempts to get an attachment's ID by it's url
 	 * @since  1.0.0
 	 * @param  string  $img_url Attachment url
-	 * @return mixed            Attachment ID or false
+	 * @return int|false            Attachment ID or false
 	 */
 	public function image_id_from_url( $img_url ) {
 		$attachment_id = 0;
 		$dir = wp_upload_dir();
-		if ( false !== strpos( $url, $dir['baseurl'] . '/' ) ) { // Is URL in uploads directory?
-			$file = basename( $url );
+		if ( false !== strpos( $img_url, $dir['baseurl'] . '/' ) ) { // Is URL in uploads directory?
+			$file = basename( $img_url );
 			$query_args = array(
 				'post_type'   => 'attachment',
 				'post_status' => 'inherit',

--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -26,25 +26,36 @@ class CMB2_Utils {
 	 * @return mixed            Attachment ID or false
 	 */
 	public function image_id_from_url( $img_url ) {
-		global $wpdb;
-
-		$img_url = esc_url_raw( $img_url );
-		// Get just the file name
-		if ( false !== strpos( $img_url, '/' ) ) {
-			$explode = explode( '/', $img_url );
-			$img_url = end( $explode );
+		$attachment_id = 0;
+		$dir = wp_upload_dir();
+		if ( false !== strpos( $url, $dir['baseurl'] . '/' ) ) { // Is URL in uploads directory?
+			$file = basename( $url );
+			$query_args = array(
+				'post_type'   => 'attachment',
+				'post_status' => 'inherit',
+				'fields'      => 'ids',
+				'meta_query'  => array(
+					array(
+						'value'   => $file,
+						'compare' => 'LIKE',
+						'key'     => '_wp_attachment_metadata',
+					),
+				)
+			);
+			$query = new WP_Query( $query_args );
+			if ( $query->have_posts() ) {
+				foreach ( $query->posts as $post_id ) {
+					$meta = wp_get_attachment_metadata( $post_id );
+					$original_file       = basename( $meta['file'] );
+					$cropped_image_files = wp_list_pluck( $meta['sizes'], 'file' );
+					if ( $original_file === $file || in_array( $file, $cropped_image_files ) ) {
+						$attachment_id = $post_id;
+						break;
+					}
+				}
+			}
 		}
-
-		// And search for a fuzzy match of the file name
-		$attachment = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE guid LIKE '%%%s%%' LIMIT 1;", $img_url ) );
-
-		// If we found an attachement ID, return it
-		if ( ! empty( $attachment ) && is_array( $attachment ) ) {
-			return $attachment[0];
-		}
-
-		// No luck
-		return false;
+		return 0 === $attachment_id ? false : $attachment_id;
 	}
 
 	/**


### PR DESCRIPTION
After having done a decent amount of research and testing on properly fetching an image ID from a URL, I've found this solution to be more robust.  Ultimately, using the guid just isn't reliable enough: http://wpscholar.com/blog/get-attachment-id-from-wp-image-url/