### PR TITLE
Update CMB2_Sanitize.php

### DIFF
--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -90,7 +90,9 @@ class CMB2_Sanitize {
 				break;
 			case 'taxonomy_select':
 			case 'taxonomy_radio':
+			case 'taxonomy_radio_inline':
 			case 'taxonomy_multicheck':
+			case 'taxonomy_multicheck_inline':
 				if ( $this->field->args( 'taxonomy' ) ) {
 					wp_set_object_terms( $this->field->object_id, $this->value, $this->field->args( 'taxonomy' ) );
 					break;


### PR DESCRIPTION
Value-changes in 'taxonomy_radio_inline'- and 'taxonomy_multicheck_inline'-fields are not being updated unless sent through default_sanitization-function.