### PR TITLE
Set terms instead of meta for taxonomy_multicheck_inline

### DIFF
--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -91,6 +91,7 @@ class CMB2_Sanitize {
 			case 'taxonomy_select':
 			case 'taxonomy_radio':
 			case 'taxonomy_multicheck':
+			case 'taxonomy_multicheck_inline':
 				if ( $this->field->args( 'taxonomy' ) ) {
 					wp_set_object_terms( $this->field->object_id, $this->value, $this->field->args( 'taxonomy' ) );
 					break;


### PR DESCRIPTION
missing from case statement, so taxonomy_multicheck_inline saves to `wp_postmeta` instead of `wp_term_relationships`