### PR TITLE
Fix adding blank entries for repeatable field with multiple inputs. Fixes #373.

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -403,6 +403,15 @@ class CMB2_Field {
 
 		if ( $this->args( 'repeatable' ) && is_array( $meta_value ) ) {
 			// Remove empties
+			if ( is_array( $meta_value[0] ) ) {
+				foreach ( $meta_value as $key => $value ) {
+					$value = array_filter( $value );
+					if ( empty( $value ) ) {
+						unset( $meta_value[ $key ] );
+					}
+				}
+			}
+
 			$meta_value = array_filter( $meta_value );
 		}
 


### PR DESCRIPTION
If the field is repeatable with multiple input (see the address field type in CMB2-Snippet-Library/custom-field-types/address-field-type.php in GitHub) CMB2 saves empty data of the hidden empty-row that generates for every repeatable field in the UI. Repeatable field with a multiple input generates an associative array in which case, sanitization_cb doesn't filter the associative values.