### PR TITLE
taxonomy_select none option fix

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -682,7 +682,7 @@ class CMB2_Types {
 			$options .= $this->select_option( array(
 				'label'   => $term->name,
 				'value'   => $term->slug,
-				'checked' => $saved_term == $term->slug,
+				'checked' => $saved_term === $term->slug,
 			) );
 		}
 


### PR DESCRIPTION
I have a taxonomy with numeric terms — 0, 1, 2, 3, etc... — and the `taxonomy_select` `option` output was looking like this:

```html
<option value="" selected="selected">None</option>
<option value="0" selected="selected">0</option>
<option value="1">1</option>
```

Doing a strict comparison seems to fix the issue and only `None` gets selected. I can then select the `0` value and it is saved and selected correctly too.