### PR TITLE
Repeatable text input save empty value as array instead of string.

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -252,7 +252,14 @@ class CMB2_Field {
 	public function update_data( $new_value, $single = true ) {
 		$a = $this->data_args( array( 'single' => $single ) );
 
-		$a['value'] = $a['repeat'] ? array_values( $new_value ) : $new_value;
+		if($a['repeat']){
+			$new_value = array_values( $new_value );
+		}
+		if(empty($new_value)){
+			$new_value = '';
+		}
+		
+		$a[ 'value' ] = $new_value;
 
 		/**
 		 * Filter whether to override saving of meta value.


### PR DESCRIPTION
Issue https://github.com/WebDevStudios/CMB2/issues/158
Fix error: Notice: Array to string conversion in /Applications/AMPPS/www/local.dev/wp-content/plugins/simple_review_final/CMB2/includes/CMB2_Types.php on line 187

Bug is still alive on trunk