### PR TITLE
Support for custom "date_format" and "time_format" arguments

### DIFF
--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -209,7 +209,19 @@ class CMB2_Sanitize {
 	 * @return string       Timestring
 	 */
 	public function text_date_timestamp() {
-		return is_array( $this->value ) ? array_map( 'strtotime', $this->value ) : strtotime( $this->value );
+		if ( is_array( $this->value ) ) {
+			$returnValue = [ ];
+			foreach ( $this->value as $value ) {
+				$date_object   = DateTime::createFromFormat( $this->field->args['date_format'], $value );
+				$returnValue[] = $date_object ? $date_object->setTime( 0, 0, 0 )->getTimeStamp() : '';
+
+			}
+		} else {
+			$date_object = DateTime::createFromFormat( $this->field->args['date_format'], $this->value );
+			$returnValue = $date_object ? $date_object->setTime( 0, 0, 0 )->getTimeStamp() : '';
+		}
+
+		return $returnValue;
 	}
 
 	/**
@@ -228,13 +240,13 @@ class CMB2_Sanitize {
 			return $repeat_value;
 		}
 
-		$this->value = strtotime( $this->value['date'] . ' ' . $this->value['time'] );
+		$this->value = DateTime::createFromFormat( $this->field->args['date_format'] .' ' .$this->field->args['time_format'], $this->value['date']. ' ' .$this->value['time'] );
 
 		if ( $tz_offset = $this->field->field_timezone_offset() ) {
 			$this->value += $tz_offset;
 		}
 
-		return $this->value;
+		return $this->value->getTimeStamp();
 	}
 
 	/**

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -500,10 +500,13 @@ class CMB2_Types {
 	}
 
 	public function text_date( $args = array() ) {
+		$dateFormat = cmb2_utils()->php_to_js_dateformat( $this->field->args( 'date_format' ) );
+
 		$args = wp_parse_args( $args, array(
 			'class' => 'cmb2-text-small cmb2-datepicker',
 			'value' => $this->field->get_timestamp_format(),
 			'desc'  => $this->_desc(),
+			'data-datepicker' => '{ "dateFormat": "' . $dateFormat  . '" }'
 		) );
 
 		CMB2_JS::add_dependencies( array( 'jquery-ui-core', 'jquery-ui-datepicker' ) );
@@ -513,6 +516,9 @@ class CMB2_Types {
 
 	// Alias for text_date
 	public function text_date_timestamp( $args = array() ) {
+		$dateFormat = cmb2_utils()->php_to_js_dateformat( $this->field->args( 'date_format' ) );
+		$args['data-datepicker'] = '{ "dateFormat": "' . $dateFormat  . '" }';
+
 		return $this->text_date( $args );
 	}
 
@@ -555,6 +561,11 @@ class CMB2_Types {
 			'desc'  => '',
 		) );
 
+		if ( $this->field->args('date_format') ) {
+			$dateFormat = cmb2_utils()->php_to_js_dateformat($this->field->args('date_format'));
+			$date_args['data-datepicker'] = '{ "dateFormat": "' . $dateFormat . '" }';
+		}
+
 		$time_args = wp_parse_args( $args['timepicker'], array(
 			'class' => 'cmb2-timepicker text-time',
 			'name'  => $this->_name( '[time]' ),
@@ -562,6 +573,11 @@ class CMB2_Types {
 			'value' => $has_good_value ? $this->field->get_timestamp_format( 'time_format', $args['value'] ) : '',
 			'desc'  => $args['desc'],
 		) );
+
+		if ( $this->field->args( 'time_format' ) ) {
+			$timeFormat = cmb2_utils()->php_to_js_dateformat($this->field->args('time_format'));
+			$time_args['data-timepicker'] = '{ "timeFormat": "' . $timeFormat . '" }';
+		}
 
 		CMB2_JS::add_dependencies( array( 'jquery-ui-core', 'jquery-ui-datepicker', 'jquery-ui-datetimepicker' ) );
 

--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -212,4 +212,49 @@ class CMB2_Utils {
 		return $this->url . $path;
 	}
 
+	/**
+	 * Takes a php date() format string and returns a string formatted to suit for the date/time pickers
+	 * It will work with only with the following subset ot date() options:
+	 *
+	 * d, j, z, m, n, y, Y, h, H and i.
+	 *
+	 * A slight effort is made to deal with escaped characters.
+	 *
+	 * Other options are ignored, because they would either bring compatibility problems between PHP and JS, or
+	 * bring even more translation troubles.
+	 *
+	 * @since 2.0.6
+	 *
+	 * @param string $format php date format
+	 *
+	 * @return string reformatted string
+	 */
+	public function php_to_js_dateformat( $format ) {
+
+		// order is relevant here, since the replacement will be done sequentially.
+		$supported_options = [
+			'd' => 'dd',  // Day, leading 0
+			'j' => 'd',   // Day, no 0
+			'z' => 'o',   // Day of the year, no leading zeroes,
+			'm' => 'mm',  // Month of the year, leading 0
+			'n' => 'm',   // Month of the year, no leading 0
+			'y' => 'y',   // Year, two digit
+			'Y' => 'yy',  // Year, full
+			'h' => 'H',   // 12-hour format of an hour with leading zeros
+			'H' => 'HH',  // 24-hour format of an hour with leading zeros
+			'i' => 'mm',  // Minutes with leading zeros
+		];
+
+		foreach ( $supported_options as $php => $js ) {
+			// replaces every instance of a supported option, but skips escaped characters
+			$format = preg_replace( "~(?<!\\\\)$php~", $js, $format );
+		}
+
+		$format = preg_replace_callback( '~(?:\\\.)+~', function ( $m ) {
+			return "&#39;" . str_replace( '\\', '', $m[0] ) . "&#39;";
+		}, $format );
+
+		return $format;
+	}
+
 }

--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -721,8 +721,13 @@ window.CMB2 = (function(window, document, $, undefined){
 			return;
 		}
 
-		$selector.timepicker( 'destroy' );
-		$selector.timepicker( cmb.defaults.time_picker );
+		$selector.each(function() {
+            var options = cmb.defaults.time_picker;
+            $(this).timepicker( 'destroy' );
+            var additionalOptions = $(this).data("timepicker");
+            $.extend( options, additionalOptions );
+            $(this).timepicker( options );
+        });
 	};
 
 	cmb.initDatePickers = function( $selector ) {
@@ -730,8 +735,13 @@ window.CMB2 = (function(window, document, $, undefined){
 			return;
 		}
 
-		$selector.datepicker( 'destroy' );
-		$selector.datepicker( cmb.defaults.date_picker );
+        $selector.each(function() {
+            var options = cmb.defaults.date_picker;
+            $(this).datepicker( 'destroy' );
+            var additionalOptions = $(this).data("datepicker");
+            $.extend( options, additionalOptions );
+            $(this).datepicker( options );
+        });
 	};
 
 	cmb.initColorPickers = function( $selector ) {


### PR DESCRIPTION
Support for custom "date_format" and "time_format" arguments for the text_date, text_date_timestamp and text_datetime_timestamp fields.

Original fixes by @yivi, based on https://github.com/WebDevStudios/CMB2/pull/318

I removed all the unrelated changes, and added support for the time picker. To make merging easier, the pull request also doesn't include a minified JS file.