### PR TITLE
Fix PHP Warning on Include Function

### DIFF
--- a/includes/helper-functions.php
+++ b/includes/helper-functions.php
@@ -29,7 +29,9 @@ function cmb2_autoload_classes( $class_name ) {
 		return;
 	}
 
-	include_once( cmb2_dir( "includes/{$class_name}.php" ) );
+	$file = cmb2_dir( "includes/{$class_name}.php" );
+	if( file_exists( $file ) )
+		include_once( $file );
 }
 
 /**


### PR DESCRIPTION
A little pre-include_once flight check. 