### PR TITLE
Fix issue with empty '' and zero '0' values in select and radio

### DIFF
--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -223,7 +223,7 @@ class CMB2_Types {
 			$a['label'] = $opt_label;
 
 			// Check if this option is the value of the input
-			if ( (string) $value === (string) $opt_value ) {
+			if ( !is_array( $value ) && (string) $value === (string) $opt_value ) {
 				$a['checked'] = 'checked';
 			}
 

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -203,7 +203,7 @@ class CMB2_Types {
 		$method = isset( $args['method'] ) ? $args['method'] : 'select_option';
 		unset( $args['method'] );
 
-		$value = $this->field->escaped_value()
+		$value = $this->field->escaped_value() !== ''
 			? $this->field->escaped_value()
 			: $this->field->args( 'default' );
 
@@ -223,7 +223,7 @@ class CMB2_Types {
 			$a['label'] = $opt_label;
 
 			// Check if this option is the value of the input
-			if ( $value == $opt_value ) {
+			if ( (string) $value === (string) $opt_value ) {
 				$a['checked'] = 'checked';
 			}
 


### PR DESCRIPTION
Issue was with both empty string '' and string with zero '0' being treated equally so both would always be selected.
This issue was present in following configuration:
```
array(
	'type'    => 'select',
	'options' => array(
		''  => 'Default',
		'1' => 'Yes',
		'0' => 'No',
	)
)
```

In proposed fix I changed it so that escaped_value is checked for an actual empty string, this way default argument is used only when there is no data in meta field and not when data is '0'. And values are converted to strings before comparison so that '0' can't be equal to '', but '0' will still match integer 0 in case someone puts integer values in their config.
