### PR TITLE
Allow for optional/empty money field.

### DIFF
--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -169,6 +169,9 @@ class CMB2_Sanitize {
 	 * @return string       Empty string or sanitized money value
 	 */
 	public function text_money() {
+		if ( '' === $this->value ) {
+			return $this->value;
+		}
 
 		global $wp_locale;
 
@@ -178,6 +181,9 @@ class CMB2_Sanitize {
 		// for repeatable
 		if ( is_array( $this->value ) ) {
 			foreach ( $this->value as $key => $val ) {
+				if ( '' === $val ) {
+					continue;
+				}
 				$this->value[ $key ] = number_format_i18n( (float) str_ireplace( $search, $replace, $val ), 2 );
 			}
 		} else {


### PR DESCRIPTION
The number formatting of fields of the text_money type caused a money field to *always* be saved.
If the field was empty, it would be saved as '0.00'.

This fix allows for the proper (non-)saving of empty money fields.