### PR TITLE
Adding field param option to remove WP default tax meta boxes

### DIFF
--- a/includes/CMB2_hookup.php
+++ b/includes/CMB2_hookup.php
@@ -242,6 +242,19 @@ class CMB2_hookup {
 					add_filter( "postbox_classes_{$post_type}_{$this->cmb->cmb_id}", array( $this, 'close_metabox_class' ) );
 				}
 
+				foreach ( $this->cmb->prop( 'fields' ) as $meta_box => $field ) {
+					if ( isset( $field['taxonomy'] ) && ! empty( $field['remove_default'] ) ) {
+						if ( ! is_taxonomy( $field['taxonomy'] ) ) {
+							continue;
+						}
+						if ( is_taxonomy_hierarchical( $field['taxonomy'] ) ) {
+							remove_meta_box( $field['taxonomy'] . 'div', $post_type, 'side' );
+						} else {
+							remove_meta_box( 'tagsdiv-' . $field['taxnomy'], $post_type, 'side' );
+						}
+					}
+				}
+
 				add_meta_box( $this->cmb->cmb_id, $this->cmb->prop( 'title' ), array( $this, 'metabox_callback' ), $post_type, $this->cmb->prop( 'context' ), $this->cmb->prop( 'priority' ) );
 			}
 		}


### PR DESCRIPTION
When adding any of the cmb2 taxonomy_* metaboxes you get both the built in wp box and the cmb2 box.  This pull request gives a field option `remove_default`.

Is this the best place to hook this in?  Seemed logical to me but I'm not real familiar with cmb2 yet.