### PR TITLE
Support for custom date and time formats for the text_datetime_timestamp and text_date_timestamp fields

### DIFF
--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -739,7 +739,7 @@ class CMB2_Field {
 	 * @return mixed         Unix timestamp representing the date.
 	 */
 	public function get_timestamp_from_value( $value ) {
-		return cmb2_utils()->get_timestamp_from_value( $value, $this->args( 'date_format' ) );
+		return cmb2_utils()->get_timestamp_from_value( $value, $this->args( 'date_format' ) . ' ' . $this->args( 'time_format' ) );
 	}
 
 	/**

--- a/includes/CMB2_Sanitize.php
+++ b/includes/CMB2_Sanitize.php
@@ -193,9 +193,18 @@ class CMB2_Sanitize {
 	 * @return string Timestring
 	 */
 	public function text_date_timestamp() {
-		return is_array( $this->value )
-			? array_map( array( $this->field, 'get_timestamp_from_value' ), $this->value )
-			: $this->field->get_timestamp_from_value( $this->value );
+		if (is_array($this->value)) {
+			$returnValue = [];
+			foreach ($this->value as $value) {
+				$date_object   = DateTime::createFromFormat($this->field->args['date_format'], $value);
+				$returnValue[] = $date_object ? $date_object->setTime(0, 0, 0)->getTimeStamp() : '';
+			}
+		} else {
+			$date_object = DateTime::createFromFormat($this->field->args['date_format'], $this->value);
+			$returnValue = $date_object ? $date_object->setTime(0, 0, 0)->getTimeStamp() : '';
+		}
+
+ 		return $returnValue;
 	}
 
 	/**

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -505,11 +505,14 @@ class CMB2_Types {
 	}
 
 	public function text_date( $args = array() ) {
+ 		$dateFormat = cmb2_utils()->php_to_js_dateformat( $this->field->args( 'date_format' ) );
+		
 		$args = wp_parse_args( $args, array(
 			'class'           => 'cmb2-text-small cmb2-datepicker',
 			'value'           => $this->field->get_timestamp_format(),
 			'desc'            => $this->_desc(),
 			'js_dependencies' => array( 'jquery-ui-core', 'jquery-ui-datepicker' ),
+ 			'data-datepicker' => '{ "dateFormat": "' . $dateFormat  . '" }'
 		) );
 
 		if ( false === strpos( $args['class'], 'timepicker' ) ) {
@@ -521,6 +524,9 @@ class CMB2_Types {
 
 	// Alias for text_date
 	public function text_date_timestamp( $args = array() ) {
+ 		$dateFormat = cmb2_utils()->php_to_js_dateformat( $this->field->args( 'date_format' ) );
+ 		$args['data-datepicker'] = '{ "dateFormat": "' . $dateFormat  . '" }';
+
 		return $this->text_date( $args );
 	}
 

--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -219,7 +219,7 @@ class CMB2_Utils {
 	 */
 	public function get_timestamp_from_value( $value, $date_format ) {
 		$date_object = date_create_from_format( $date_format, $value );
-		return $date_object ? $date_object->setTime( 0, 0, 0 )->getTimeStamp() : strtotime( $value );
+		return $date_object ? $date_object->getTimeStamp() : strtotime( $value );
 	}
 
 	/**


### PR DESCRIPTION
The "date_format" and "time_format" arguments didn't work with fields of type "text_datetime_timestamp" or "text_date_timestamp". 
I reported and fixed this already in #498, but some other fix was applied that only worked for other date/time fields, but not those two. This is basically just a rebase of #498 with the missing fix for  "text_datetime_timestamp" and "text_date_timestamp".