### PR TITLE
Autoload init file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"
+    },
+    "autoload": {
+        "files": ["init.php"]
     }
 }


### PR DESCRIPTION
When using composer we should autoload the init file so we have immediate access to the CMB2 functionality