### PR TITLE
Update travis file for non-specific PHP minor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
     - 5.4
     - 5.5
     - 5.6
-    - 7.0.1
+    - 7.0
     - hhvm
     - nightly
 
@@ -27,9 +27,9 @@ matrix:
     - env: WP_VERSION=latest WP_MULTISITE=1
       php: nightly
     - env: WP_VERSION=3.8 WP_MULTISITE=0
-      php: 7.0.1
+      php: 7.0
     - env: WP_VERSION=3.8 WP_MULTISITE=1
-      php: 7.0.1
+      php: 7.0
 
 before_script:
     - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
Use unspecified PHP 7 minor in favour of specified one to ensure always using the latest available via Travis.