### PR TITLE
Make the Title field type handles extra args

### DIFF
--- a/includes/types/CMB2_Type_Title.php
+++ b/includes/types/CMB2_Type_Title.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CMB title field type
  *
@@ -13,15 +14,16 @@
 class CMB2_Type_Title extends CMB2_Type_Base {
 
 	public function render() {
+		$args = empty( $args ) ? $this->args : $args;
 		$a = $this->parse_args( 'title', array(
 			'tag'   => $this->field->object_type == 'post' ? 'h5' : 'h3',
 			'class' => 'cmb2-metabox-title',
 			'name'  => $this->field->args( 'name' ),
 			'desc'  => $this->_desc( true ),
-		) );
+		), $args );
 
 		return $this->rendered(
-			sprintf( '<%1$s class="%2$s">%3$s</%1$s>%4$s', $a['tag'], $a['class'], $a['name'], $a['desc'] )
+			sprintf( '<%1$s %2$s/>%3$s</%1$s>%4$s', $a['tag'], $this->concat_attrs( $a, array( 'tag', 'name', 'desc' ) ), $a['name'], $a['desc'] )
 		);
 	}
 

--- a/includes/types/CMB2_Type_Title.php
+++ b/includes/types/CMB2_Type_Title.php
@@ -26,7 +26,7 @@ class CMB2_Type_Title extends CMB2_Type_Base {
 			'class' => 'cmb2-metabox-title',
 			'name'  => $this->field->args( 'name' ),
 			'desc'  => $this->_desc( true ),
-		), $this->args );
+		) );
 
 		return $this->rendered(
 			sprintf( '<%1$s %2$s>%3$s</%1$s>%4$s', $a['tag'], $this->concat_attrs( $a, array( 'tag', 'name', 'desc' ) ), $a['name'], $a['desc'] )

--- a/includes/types/CMB2_Type_Title.php
+++ b/includes/types/CMB2_Type_Title.php
@@ -13,7 +13,14 @@
  */
 class CMB2_Type_Title extends CMB2_Type_Base {
 
-	public function render() {
+	/**
+	 * Handles outputting an 'title' element
+	 *
+	 * @param  array $args Override arguments
+	 *
+	 * @return string       Heading element
+	 */
+	public function render( $args = array() ) {
 		$args = empty( $args ) ? $this->args : $args;
 		$a = $this->parse_args( 'title', array(
 			'tag'   => $this->field->object_type == 'post' ? 'h5' : 'h3',

--- a/includes/types/CMB2_Type_Title.php
+++ b/includes/types/CMB2_Type_Title.php
@@ -20,17 +20,16 @@ class CMB2_Type_Title extends CMB2_Type_Base {
 	 *
 	 * @return string       Heading element
 	 */
-	public function render( $args = array() ) {
-		$args = empty( $args ) ? $this->args : $args;
+	public function render() {
 		$a = $this->parse_args( 'title', array(
 			'tag'   => $this->field->object_type == 'post' ? 'h5' : 'h3',
 			'class' => 'cmb2-metabox-title',
 			'name'  => $this->field->args( 'name' ),
 			'desc'  => $this->_desc( true ),
-		), $args );
+		), $this->args );
 
 		return $this->rendered(
-			sprintf( '<%1$s %2$s/>%3$s</%1$s>%4$s', $a['tag'], $this->concat_attrs( $a, array( 'tag', 'name', 'desc' ) ), $a['name'], $a['desc'] )
+			sprintf( '<%1$s %2$s>%3$s</%1$s>%4$s', $a['tag'], $this->concat_attrs( $a, array( 'tag', 'name', 'desc' ) ), $a['name'], $a['desc'] )
 		);
 	}
 


### PR DESCRIPTION
Currently, the Title type didn't take into consideration extra arguments like 'attributes'. Now it does, just like the rest of the fields. This will allow for add-ons like CMB2-conditionals to work for this field type also.