### PR TITLE
Path issues with JS and CSS

### DIFF
--- a/includes/CMB2_Utils.php
+++ b/includes/CMB2_Utils.php
@@ -251,7 +251,7 @@ class CMB2_Utils {
 
 		// Check to see if it's anywhere in the root directory
 
-		$site_dir = ABSPATH;
+		$site_dir = self::normalize_path( ABSPATH );
 		$site_url = trailingslashit( is_multisite() ? network_site_url() : site_url() );
 
 		$url = str_replace(


### PR DESCRIPTION
Solve issues with asset paths on Windows/Xampp
The ABSPATH ($site_dir) is run through your normalize path function as you already do with $dir inside get_url_from_dir()

Fixes #676