### PR TITLE
update files to be PHP7 compatible

### DIFF
--- a/css/index.php
+++ b/css/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden

--- a/css/sass/index.php
+++ b/css/sass/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden

--- a/css/sass/partials/index.php
+++ b/css/sass/partials/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden

--- a/images/index.php
+++ b/images/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden

--- a/includes/CMB2_Field.php
+++ b/includes/CMB2_Field.php
@@ -962,7 +962,7 @@ class CMB2_Field extends CMB2_Base {
 	 * @param  string  $fallback Fallback text
 	 * @return string            Text
 	 */
-	public function string( $text_key, $fallback ) {
+	public function get_string( $text_key, $fallback ) {
 		// If null, populate with our field strings values.
 		if ( null === $this->strings ) {
 			$this->strings = (array) $this->args['text'];

--- a/includes/CMB2_Types.php
+++ b/includes/CMB2_Types.php
@@ -187,7 +187,7 @@ class CMB2_Types {
 	 * @return string            Text
 	 */
 	public function _text( $text_key, $fallback = '' ) {
-		return $this->field->string( $text_key, $fallback );
+		return $this->field->get_string( $text_key, $fallback );
 	}
 
 	/**

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden

--- a/index.php
+++ b/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden

--- a/js/index.php
+++ b/js/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden

--- a/tests/index.php
+++ b/tests/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden


### PR DESCRIPTION
Fixes #719 .

### Changes proposed in this pull request

-  Add <?php opening tag to empty php files

-  Rename `CMB_Field->string()` function to `CMB_Field->get_string()` (string is a reserved keyword in PHP 7.0)



