### PR TITLE
Remove object_type default

### DIFF
--- a/includes/CMB2_Base.php
+++ b/includes/CMB2_Base.php
@@ -43,7 +43,7 @@ abstract class CMB2_Base {
 	 * @var   string
 	 * @since 2.2.3
 	 */
-	protected $object_type = 'post';
+	protected $object_type = '';
 
 	/**
 	 * Array of key => value data for saving. Likely $_POST data.


### PR DESCRIPTION
Fixes #700.

Discussion: https://wordpress.org/support/topic/term-meta-is-saved-but-it-doesnt-appear-in-term-edit-screen-later/page/2/#post-8259773

So order matters here due to the caching pattern used in CMB2_

```
        public function object_type( $object_type = '' ) {
                if ( $object_type ) {
                        $this->object_type = $object_type;
                        return $this->object_type;
                }

                if ( $this->object_type ) {
                        return $this->object_type;
                }

                $this->object_type = $this->current_object_type();

                return $this->object_type;
        }
```

Which I think explains why different folks report different results.  Depending on the order things get initialized in, object_type could be set differently.

However, in the case where nothing else is setting object_type (this only happens during `render_form_open` and `render_form_close`), then in the above logic, current_object_type is _NEVER_ called, because $this->object_type is already defaulted to 'post'.

If you remove that default, everything works great!
### Changes proposed in this pull request
-  Sets default `object_type` to null for CMB2_Base
