### PR TITLE
Use quotes for label[for=""] selecttor

### DIFF
--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -197,7 +197,7 @@ window.CMB2 = window.CMB2 || {};
 
 		// Create the media frame.
 		media.frames[ media.field ] = wp.media( {
-			title: cmb.metabox().find('label[for=' + media.field + ']').text(),
+			title: cmb.metabox().find('label[for="' + media.field + '"]').text(),
 			library : media.fieldData.queryargs || {},
 			button: {
 				text: l10n.strings[ isList ? 'upload_files' : 'upload_file' ]


### PR DESCRIPTION
Also fixed `Syntax error, unrecognized expression:` when call CMB2 in widget (ID key has contains `[`, `]` character)
