### PR TITLE
$.closest() instead of parents()

### DIFF
--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -314,7 +314,7 @@ window.CMB2 = window.CMB2 || {};
 		evt.preventDefault();
 		var $this = $( this );
 		if ( $this.is( '.cmb-attach-list .cmb2-remove-file-button' ) ){
-			$this.parents('li').remove();
+			$this.closest('li').remove();
 			return false;
 		}
 


### PR DESCRIPTION
In case I have a `li` tag wrapper `.cmb-row`, click (x) button will remove li parent.
Fixed that with closest() method.


