### PR TITLE
Fixed object-type detection of the `CMB2::current_object_type()` method

### DIFF
--- a/includes/CMB2.php
+++ b/includes/CMB2.php
@@ -953,6 +953,14 @@ class CMB2 extends CMB2_Base {
 			$type = 'term';
 		}
 
+		if ( $pagenow === 'admin-ajax.php' && isset($_POST['action']) ) {
+		    switch ( $_POST['action'] ) {
+			case 'add-tag':
+			    $type = 'term';
+			    break;
+		    }
+		}
+
 		return $type;
 	}
 


### PR DESCRIPTION
to handle the 'add-tag' action of the 'admin-ajax.php' page.

Fixes #841.

### Changes proposed in this pull request

-  Add a new check to see if the current page is `admin-ajax.php` and if an **action** parameter exists within the $_POST variable determine object-type based on it's value.

PS: AFAICT, there is only one entry point into the plugin's execution flow via the 'admin-ajax.php' page and this applies to this specific scenario / **term** object-type therefore the **action** parameter validation is sort of useless however, perhaps this might change in the near future so I'm recommending we leave it there.