### PR TITLE
Update "Image" Definition

### DIFF
--- a/js/cmb2.js
+++ b/js/cmb2.js
@@ -265,7 +265,7 @@ window.CMB2 = window.CMB2 || {};
 		};
 
 		handlers.getAttachmentHtml = function( attachment, templatesId ) {
-			var isImage = 'image' === attachment.get( 'type' );
+			var isImage = (('image' === attachment.get( 'type' )) && (_.contains( wp.media.view.settings.embedExts, attachment.get('filename').split('.').pop())));
 			var data    = handlers.prepareData( attachment, isImage );
 
 			// Image preview or standard generic output if it's not an image.


### PR DESCRIPTION
If SVG Upload is enabled, SVG can't be chosen in file_list Field because it is MIME-Type "image", but doesn't have Size Data.