### PR TITLE
Get PHP7 builds to pass on Travis again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,15 @@ matrix:
       php: 7.0
     - env: WP_VERSION=3.8 WP_MULTISITE=1
       php: 7.0
-    - env: WP_VERSION=latest WP_MULTISITE=0
-      php: 7.0
-    - env: WP_VERSION=latest WP_MULTISITE=1
-      php: 7.0
 
 before_script:
+    - export PATH="$HOME/.composer/vendor/bin:$PATH"
+    - |
+      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
+       composer global require "phpunit/phpunit=5.7.*"
+      else
+        composer global require "phpunit/phpunit=4.8.*"
+      fi
     - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 script: if [[ latest == $WP_VERSION ]]; then phpunit --coverage-clover=coverage.clover; else phpunit --exclude-group cmb2-rest-api --coverage-clover=coverage.clover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,15 @@ matrix:
       php: 7.0
 
 before_script:
-    - export PATH="$HOME/.composer/vendor/bin:$PATH"
-    - |
-      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-       composer global require "phpunit/phpunit=5.7.*"
-      else
-        composer global require "phpunit/phpunit=4.8.*"
-      fi
-    - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
+     composer global require "phpunit/phpunit=5.7.*"
+    else
+      composer global require "phpunit/phpunit=4.8.*"
+    fi
+  - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+  - phpunit --version
 
 script: if [[ latest == $WP_VERSION ]]; then phpunit --coverage-clover=coverage.clover; else phpunit --exclude-group cmb2-rest-api --coverage-clover=coverage.clover; fi
 


### PR DESCRIPTION
WordPress' test suite fails on PHP7 in Travis currently because of the version of PHPUnit (6) Travis includes on their PHP7.x builds.

[Core ticket 40086](https://core.trac.wordpress.org/ticket/40086) fixes this until [WordPress' test suite is updated to support PHPUunit 6](https://core.trac.wordpress.org/ticket/39822).

This pull should pass on PHP7 instead of allowing it to fail.