### PR TITLE
Fix WP VIP PHPCS in example-functions

### DIFF
--- a/example-functions.php
+++ b/example-functions.php
@@ -115,7 +115,7 @@ function yourprefix_register_demo_metabox() {
 	$cmb_demo = new_cmb2_box( array(
 		'id'            => $prefix . 'metabox',
 		'title'         => esc_html__( 'Test Metabox', 'cmb2' ),
-		'object_types'  => array( 'page', ), // Post type
+		'object_types'  => array( 'page' ), // Post type
 		// 'show_on_cb' => 'yourprefix_show_if_front_page', // function should return a bool value
 		// 'context'    => 'normal',
 		// 'priority'   => 'high',
@@ -385,7 +385,9 @@ function yourprefix_register_demo_metabox() {
 		'desc'    => esc_html__( 'field description (optional)', 'cmb2' ),
 		'id'      => $prefix . 'wysiwyg',
 		'type'    => 'wysiwyg',
-		'options' => array( 'textarea_rows' => 5, ),
+		'options' => array(
+			'textarea_rows' => 5,
+		),
 	) );
 
 	$cmb_demo->add_field( array(
@@ -441,11 +443,13 @@ function yourprefix_register_about_page_metabox() {
 	$cmb_about_page = new_cmb2_box( array(
 		'id'           => $prefix . 'metabox',
 		'title'        => esc_html__( 'About Page Metabox', 'cmb2' ),
-		'object_types' => array( 'page', ), // Post type
+		'object_types' => array( 'page' ), // Post type
 		'context'      => 'normal',
 		'priority'     => 'high',
 		'show_names'   => true, // Show field names on the left
-		'show_on'      => array( 'id' => array( 2, ) ), // Specific post IDs to display this metabox
+		'show_on'      => array(
+			'id' => array( 2 ),
+		), // Specific post IDs to display this metabox
 	) );
 
 	$cmb_about_page->add_field( array(
@@ -470,7 +474,7 @@ function yourprefix_register_repeatable_group_field_metabox() {
 	$cmb_group = new_cmb2_box( array(
 		'id'           => $prefix . 'metabox',
 		'title'        => esc_html__( 'Repeating Field Group', 'cmb2' ),
-		'object_types' => array( 'page', ),
+		'object_types' => array( 'page' ),
 	) );
 
 	// $group_field_id is the field id string, so in this case: $prefix . 'demo'
@@ -652,7 +656,7 @@ function yourprefix_register_theme_options_metabox() {
 		'show_on' => array(
 			// These are important, don't remove.
 			'key'   => 'options-page',
-			'value' => array( $option_key )
+			'value' => array( $option_key ),
 		),
 	) );
 
@@ -699,7 +703,7 @@ function yourprefix_register_rest_api_box() {
 	$cmb_rest = new_cmb2_box( array(
 		'id'            => $prefix . 'metabox',
 		'title'         => esc_html__( 'REST Test Box', 'cmb2' ),
-		'object_types'  => array( 'page', ), // Post type
+		'object_types'  => array( 'page' ), // Post type
 		'show_in_rest' => WP_REST_Server::ALLMETHODS, // WP_REST_Server::READABLE|WP_REST_Server::EDITABLE, // Determines which HTTP methods the box is visible in.
 		// Optional callback to limit box visibility.
 		// See: https://github.com/WebDevStudios/CMB2/wiki/REST-API#permissions
@@ -718,6 +722,6 @@ function yourprefix_register_rest_api_box() {
 		'desc'       => esc_html__( 'Will show in REST API "editable" contexts only (`POST` requests).', 'cmb2' ),
 		'id'         => $prefix . 'editable_text',
 		'type'       => 'text',
-		'show_in_rest' => WP_REST_Server::EDITABLE// WP_REST_Server::ALLMETHODS|WP_REST_Server::READABLE, // Determines which HTTP methods the field is visible in. Will override the cmb2_box 'show_in_rest' param.
+		'show_in_rest' => WP_REST_Server::EDITABLE,// WP_REST_Server::ALLMETHODS|WP_REST_Server::READABLE, // Determines which HTTP methods the field is visible in. Will override the cmb2_box 'show_in_rest' param.
 	) );
 }


### PR DESCRIPTION
Indentation, no actual code changes 